### PR TITLE
Swappable model for database backend

### DIFF
--- a/django_mail_viewer/backends/database/__init__.py
+++ b/django_mail_viewer/backends/database/__init__.py
@@ -1,1 +1,1 @@
-
+from .backend import EmailBackend

--- a/django_mail_viewer/backends/database/apps.py
+++ b/django_mail_viewer/backends/database/apps.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 
 
 class DatabaseBackendConfig(AppConfig):
-    label = 'mailviewer_database_backend'
+    label = 'mail_viewer_database_backend'
     name = 'django_mail_viewer.backends.database'
     # May want to change this verbose_name
     verbose_name = _("Database Backend")

--- a/django_mail_viewer/backends/database/migrations/0001_initial.py
+++ b/django_mail_viewer/backends/database/migrations/0001_initial.py
@@ -21,8 +21,8 @@ class Migration(migrations.Migration):
                 ('content', models.TextField(blank=True, default='')),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('updated_at', models.DateTimeField(auto_now=True)),
-                ('file_attachment', models.FileField(blank=True, default='', upload_to='mailviewer_attachments')),
-                ('parent', models.ForeignKey(blank=True, default=None, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='parts', to='mailviewer_database_backend.emailmessage')),
+                ('file_attachment', models.FileField(blank=True, default='', upload_to='mail_viewer_attachments')),
+                ('parent', models.ForeignKey(blank=True, default=None, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='parts', to='mail_viewer_database_backend.emailmessage')),
             ],
             options={
                 'db_table': 'mail_viewer_emailmessage',

--- a/django_mail_viewer/settings.py
+++ b/django_mail_viewer/settings.py
@@ -5,3 +5,4 @@ from django.conf import settings
 # The cache config from django.core.cache.caches to use for backends.cache.CacheBackend
 # default to django.core.cache.caches['default']
 MAILVIEWER_CACHE = getattr(settings, 'MAILVIEWER_CACHE', 'default')
+MAILVIEWER_DATABASE_BACKEND_MODEL = getattr(settings, 'MAILVIEWER_DATABASE_BACKEND_MODEL', 'mail_viewer_database_backend.EmailMessage')

--- a/runtests.py
+++ b/runtests.py
@@ -19,6 +19,7 @@ try:
             "django.contrib.contenttypes",
             "django.contrib.sites",
             "django_mail_viewer",
+            "django_mail_viewer.backends.database.apps.DatabaseBackendConfig",
         ],
         SITE_ID=1,
         MIDDLEWARE_CLASSES=(),

--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -10,7 +10,14 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.1/ref/settings/
 """
 
-EMAIL_BACKEND = 'django_mail_viewer.backends.database.backend.EmailBackend'
+EMAIL_BACKEND = 'django_mail_viewer.backends.database.EmailBackend'
+# EMAIL_BACKEND = 'django_mail_viewer.backends.cache.EmailBackend'
+# CACHES = {
+#     'default': {
+#         'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+#         'LOCATION': '/tmp/django_cache',
+#     }
+# }
 
 from pathlib import Path
 


### PR DESCRIPTION
* Made the model used for database backend email storage a setting and
loaded at runtime. This allows users to use their own model, as the docs
suggest for certain use cases, and allows the backend to be referenced
in the same way the others are without the extra package
name/namespacing.
* Normalized usage of mailviewer vs mail_viewer in some places
* Moved a bunch of methods from EmailMessage to AbstractBaseEmailMessage
* Minor type hinting improvements