### PR TITLE
Use re_path in urls.py

### DIFF
--- a/django_mail_viewer/urls.py
+++ b/django_mail_viewer/urls.py
@@ -3,12 +3,12 @@ from django.urls import re_path
 from . import views
 
 urlpatterns = [
-    url(
+    re_path(
         r'message/(?P<message_id>.+)/attachment/(?P<attachment>.+)/$',
         views.EmailAttachmentDownloadView.as_view(),
         name="mail_viewer_attachment",
     ),
-    url(r'message/(?P<message_id>.+)/delete/$', views.EmailDeleteView.as_view(), name="mail_viewer_delete"),
-    url(r'message/(?P<message_id>.+)/$', views.EmailDetailView.as_view(), name='mail_viewer_detail'),
-    url(r'', views.EmailListView.as_view(), name='mail_viewer_list'),
+    re_path(r'message/(?P<message_id>.+)/delete/$', views.EmailDeleteView.as_view(), name="mail_viewer_delete"),
+    re_path(r'message/(?P<message_id>.+)/$', views.EmailDetailView.as_view(), name='mail_viewer_detail'),
+    re_path(r'', views.EmailListView.as_view(), name='mail_viewer_list'),
 ]

--- a/django_mail_viewer/urls.py
+++ b/django_mail_viewer/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 


### PR DESCRIPTION
Quick update of urls.py to use re_path instead of django.conf.urls.url which has been removed as of Django 4.0. Update to just django.urls.path later.