### PR TITLE
Update linters formatters and supported versions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        django-version: ["django==4.1.*", "django==4.2.*", "django==5.0.*", "django==5.1.*", "django==5.2.*"]
+        exclude:
+          - python-version: "3.8"
+            django-version: "django>4.2"
+          - python-version: "3.9"
+            django-version: "django>4.2"
+          - python-version: "3.12"
+            django-version: "django<4.2.8"
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -24,11 +32,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements_test.txt
-      - name: Lint with flake8
+      - name: Lint with ruff
         run: |
           # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          make ruff-check
       - name: Run Tox
         run: tox

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,15 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        django-version: ["django==4.1.*", "django==4.2.*", "django==5.0.*", "django==5.1.*", "django==5.2.*"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13.0-rc.1"]
+        django-version: ["django==4.2.*", "django==5.0.*", "django==5.1.*", "django==5.2.*"]
         exclude:
-          - python-version: "3.8"
-            django-version: "django>4.2"
-          - python-version: "3.9"
-            django-version: "django>4.2"
           - python-version: "3.12"
             django-version: "django<4.2.8"
+          - python-version: "3.13.0-rc.1"
+            django-version: "django<5.2"
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,9 +1,0 @@
-[style]
-based_on_style = pep8
-column_limit = 120
-split_before_named_assigns = false
-dedent_closing_brackets = false
-split_before_logical_operator = false
-allow_multiline_dictionary_keys = true
-indent_dictionary_value = true
-split_before_first_argument = false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-buster AS dev
+FROM python:3.8-bookworm AS dev
 # Dockerfile for running a test django installation
 LABEL maintainer="Justin Michalicek <jmichalicek@gmail.com>"
 ENV PYTHONUNBUFFERED 1
@@ -8,7 +8,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteract
   software-properties-common \
   sudo \
   vim \
-  telnet \
   postgresql-client \
   && apt-get autoremove && apt-get clean
 

--- a/Makefile
+++ b/Makefile
@@ -91,3 +91,12 @@ install-mailviewer:
 
 black:
 	black django_mail_viewer tests test_project
+
+black-check:
+	black --check --diff django_mail_viewer tests test_project
+
+ruff:
+	ruff check django_mail_viewer --fix
+
+ruff-check:
+	ruff check django_mail_viewer

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ setup-and-run:	setup migrate run
 
 venv:
 	 python -m venv .venv
+	 pip install --upgrade pip wheel setuptools
 
 run:
 	python manage.py runserver 0.0.0.0:8000
@@ -81,8 +82,12 @@ migrate:
 
 dev:
 	docker compose run --service-ports django /bin/bash
+
 shell:
 	docker compose exec django /bin/bash
 
 install-mailviewer:
 	pip install -e /django/mailviewer --no-binary :all:
+
+black:
+	black django_mail_viewer tests test_project

--- a/django_mail_viewer/apps.py
+++ b/django_mail_viewer/apps.py
@@ -2,5 +2,5 @@ from django.apps import AppConfig
 
 
 class DjangoMailViewerConfig(AppConfig):
-    name = 'django_mail_viewer'
+    name = "django_mail_viewer"
     verbose_name = "Django Mail Viewer"

--- a/django_mail_viewer/backends/cache.py
+++ b/django_mail_viewer/backends/cache.py
@@ -1,6 +1,7 @@
 """
 Backend for test environment.
 """
+
 from contextlib import contextmanager
 from os import getpid
 from time import monotonic, sleep
@@ -27,14 +28,14 @@ class EmailBackend(BaseEmailBackend):
         # This is for get_outbox() so that the system knows which cache keys are there
         # to retrieve them. Django does not have a built in way to get the keys
         # which exist in the cache.
-        self.cache_keys_key = 'message_keys'
-        self.cache_keys_lock_key = 'message_keys_lock'
+        self.cache_keys_key = "message_keys"
+        self.cache_keys_lock_key = "message_keys_lock"
 
     def send_messages(self, messages):
         msg_count = 0
         for message in messages:
             m = message.message()
-            message_id = m.get('message-id')
+            message_id = m.get("message-id")
             self.cache.set(message_id, m)
 
             # Use a lock key and spinlock
@@ -57,7 +58,7 @@ class EmailBackend(BaseEmailBackend):
                         msg_count += 1
                         is_stored = True
                     else:
-                        sleep(.01)
+                        sleep(0.01)
         return msg_count
 
     def get_message(self, lookup_id):

--- a/django_mail_viewer/backends/database/admin.py
+++ b/django_mail_viewer/backends/database/admin.py
@@ -4,9 +4,9 @@ from .models import EmailMessage
 
 
 class EmailMessageAdmin(admin.ModelAdmin):
-    list_display = ('pk', 'parent', 'message_id', 'created_at', 'updated_at')
-    search_fields = ('pk', 'message_id', 'message_headers')
-    readonly_fields = ('created_at', 'updated_at')
+    list_display = ("pk", "parent", "message_id", "created_at", "updated_at")
+    search_fields = ("pk", "message_id", "message_headers")
+    readonly_fields = ("created_at", "updated_at")
 
 
 admin.site.register(EmailMessage, EmailMessageAdmin)

--- a/django_mail_viewer/backends/database/apps.py
+++ b/django_mail_viewer/backends/database/apps.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 
 
 class DatabaseBackendConfig(AppConfig):
-    label = 'mail_viewer_database_backend'
-    name = 'django_mail_viewer.backends.database'
+    label = "mail_viewer_database_backend"
+    name = "django_mail_viewer.backends.database"
     # May want to change this verbose_name
     verbose_name = _("Database Backend")

--- a/django_mail_viewer/backends/database/backend.py
+++ b/django_mail_viewer/backends/database/backend.py
@@ -62,9 +62,9 @@ class EmailBackend(BaseEmailBackend):
                     elif name == "read-date":
                         attachment.read_date = value  # TODO: datetime
                 return {
-                    'filename': Path(message.get_filename()).name,
-                    'content_type': message.get_content_type(),
-                    'file': attachment,
+                    "filename": Path(message.get_filename()).name,
+                    "content_type": message.get_content_type(),
+                    "file": attachment,
                 }
         return None
 
@@ -76,11 +76,11 @@ class EmailBackend(BaseEmailBackend):
             if message.is_multipart():
                 # TODO: Should this really be done recursively? I believe forwarded emails may
                 # have multiple layers of parts/dispositions
-                message_id = message.get('message-id')
+                message_id = message.get("message-id")
                 main_message = None
                 for i, part in enumerate(message.walk()):
                     content_type = part.get_content_type()
-                    charset = part.get_param('charset')
+                    charset = part.get_param("charset")
                     # handle attachments - probably need to look at SingleEmailMixin._parse_email_attachment()
                     # and make that more reusable
                     content_disposition = part.get("Content-Disposition", None)
@@ -88,18 +88,18 @@ class EmailBackend(BaseEmailBackend):
                         # attachment_data = part.get_payload(decode=True)
                         attachment_data = self._parse_email_attachment(part)
                         file_attachment = ContentFile(
-                            attachment_data.get('file').read(), name=attachment_data.get('filename', 'attachment')
+                            attachment_data.get("file").read(), name=attachment_data.get("filename", "attachment")
                         )
-                        content = ''
-                    elif content_type in ['text/plain', 'text/html']:
-                        content = part.get_payload(decode=True).decode(charset, errors='replace')
-                        file_attachment = ''
+                        content = ""
+                    elif content_type in ["text/plain", "text/html"]:
+                        content = part.get_payload(decode=True).decode(charset, errors="replace")
+                        file_attachment = ""
                     else:
                         # the main multipart/alternative message for multipart messages has no content/payload
                         # TODO: handle file attachments
-                        content = ''
-                        file_attachment = ''
-                    message_id = part.get('message-id', '')  # do sub-parts have a message-id?
+                        content = ""
+                        file_attachment = ""
+                    message_id = part.get("message-id", "")  # do sub-parts have a message-id?
                     p = self._backend_model(
                         message_id=message_id,
                         content=content,
@@ -111,7 +111,7 @@ class EmailBackend(BaseEmailBackend):
                     if i == 0:
                         main_message = p
             else:
-                message_id = message.get('message-id')
+                message_id = message.get("message-id")
                 main_message = self._backend_model(
                     message_id=message_id,
                     content=message.get_payload(),

--- a/django_mail_viewer/backends/locmem.py
+++ b/django_mail_viewer/backends/locmem.py
@@ -1,6 +1,7 @@
 """
 Backend for test environment.
 """
+
 from django.core import mail
 from django.core.mail.backends.base import BaseEmailBackend
 
@@ -18,7 +19,7 @@ class EmailBackend(BaseEmailBackend):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if not hasattr(mail, 'outbox'):
+        if not hasattr(mail, "outbox"):
             mail.outbox = []
 
     def send_messages(self, messages):
@@ -38,7 +39,7 @@ class EmailBackend(BaseEmailBackend):
             # differently than the expected Message-ID,  which is suppored by
             # EmailMessage.message(), then we can't just access the key directly.  Instead iterate
             # over the keys and vls
-            if message.get('message-id') == lookup_id:
+            if message.get("message-id") == lookup_id:
                 return message
         return None
 
@@ -47,16 +48,16 @@ class EmailBackend(BaseEmailBackend):
         Get the outbox used by this backend.  This backend returns a copy of mail.outbox.
         May add pagination args/kwargs.
         """
-        return getattr(mail, 'outbox', [])[:]
+        return getattr(mail, "outbox", [])[:]
 
     def delete_message(self, message_id: str):
         """
         Remove the message with the given id from the mailbox
         """
-        outbox = getattr(mail, 'outbox', [])
+        outbox = getattr(mail, "outbox", [])
         index_to_remove = None
         for idx, message in enumerate(outbox):
-            if message.get('message-id') == message_id:
+            if message.get("message-id") == message_id:
                 index_to_remove = idx
                 break
         if index_to_remove is not None:

--- a/django_mail_viewer/settings.py
+++ b/django_mail_viewer/settings.py
@@ -2,5 +2,7 @@ from django.conf import settings
 
 # The cache config from django.core.cache.caches to use for backends.cache.CacheBackend
 # default to django.core.cache.caches['default']
-MAILVIEWER_CACHE = getattr(settings, 'MAILVIEWER_CACHE', 'default')
-MAILVIEWER_DATABASE_BACKEND_MODEL = getattr(settings, 'MAILVIEWER_DATABASE_BACKEND_MODEL', 'mail_viewer_database_backend.EmailMessage')
+MAILVIEWER_CACHE = getattr(settings, "MAILVIEWER_CACHE", "default")
+MAILVIEWER_DATABASE_BACKEND_MODEL = getattr(
+    settings, "MAILVIEWER_DATABASE_BACKEND_MODEL", "mail_viewer_database_backend.EmailMessage"
+)

--- a/django_mail_viewer/templatetags/mail_viewer_tags.py
+++ b/django_mail_viewer/templatetags/mail_viewer_tags.py
@@ -25,7 +25,7 @@ def message_lookup_id(message):
     making it inaccessible directly.
     """
 
-    return mark_safe(message.get('message-id', '').strip('<>'))
+    return mark_safe(message.get("message-id", "").strip("<>"))
 
 
 @register.simple_tag

--- a/django_mail_viewer/urls.py
+++ b/django_mail_viewer/urls.py
@@ -4,11 +4,11 @@ from . import views
 
 urlpatterns = [
     re_path(
-        r'message/(?P<message_id>.+)/attachment/(?P<attachment>.+)/$',
+        r"message/(?P<message_id>.+)/attachment/(?P<attachment>.+)/$",
         views.EmailAttachmentDownloadView.as_view(),
         name="mail_viewer_attachment",
     ),
-    re_path(r'message/(?P<message_id>.+)/delete/$', views.EmailDeleteView.as_view(), name="mail_viewer_delete"),
-    re_path(r'message/(?P<message_id>.+)/$', views.EmailDetailView.as_view(), name='mail_viewer_detail'),
-    re_path(r'', views.EmailListView.as_view(), name='mail_viewer_list'),
+    re_path(r"message/(?P<message_id>.+)/delete/$", views.EmailDeleteView.as_view(), name="mail_viewer_delete"),
+    re_path(r"message/(?P<message_id>.+)/$", views.EmailDetailView.as_view(), name="mail_viewer_detail"),
+    re_path(r"", views.EmailListView.as_view(), name="mail_viewer_list"),
 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   database:
     image: "postgres:11.2"
@@ -17,7 +16,6 @@ services:
       - redis:/data
   django:
     image: django-mailviewer:dev
-    #command: /bin/bash -ic 'make setup-and-run'
     command: /bin/bash
     stdin_open: true
     tty: true
@@ -25,14 +23,12 @@ services:
       - database
       - redis
     working_dir: /django/mailviewer/
-    # command: /home/developer/docker_entrypoints/dev_entrypoint.sh
     build:
       context: .
       dockerfile: Dockerfile
       target: dev
     environment:
       - REDIS_HOST=redis
-      # - DJANGO_SETTINGS_MODULE=bash_shell_net.settings.local
       - SHELL=/bin/bash
       - DATABASE_URL=postgres://developer:developer@database:5432/django_mailviewer
       - LOG_LEVEL=DEBUG
@@ -41,9 +37,8 @@ services:
     restart: on-failure
     volumes:
       - .:/django/mailviewer/
-      - ~/.git-hooks:/django/.git-hooks:ro
-      - ~/.gitconfig:/django/.gitconfig:ro
-      - ~/.ssh:/django/.ssh:ro
+      - ~/.gitconfig:/django/.gitconfig
+      - ~/.ssh:/django/.ssh
 volumes:
   db:
   redis:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ django_settings_module = "test_project.test_project.settings"
 
 [tool.black]
 line-length = 120
-skip-string-normalization = true
 exclude = '''
   migrations
 '''

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -8,4 +8,5 @@ django-stubs
 mypy
 typing-extensions
 black
+ruff
 # Additional test requirements go here

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,4 +7,5 @@ tox-gh-actions
 django-stubs
 mypy
 typing-extensions
+black
 # Additional test requirements go here

--- a/test_project/manage.py
+++ b/test_project/manage.py
@@ -6,7 +6,7 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'test_project.settings')
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "test_project.settings")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:
@@ -18,5 +18,5 @@ def main():
     execute_from_command_line(sys.argv)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/test_project/test_project/asgi.py
+++ b/test_project/test_project/asgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'test_project.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "test_project.settings")
 
 application = get_asgi_application()

--- a/test_project/test_project/management/commands/send_test_email.py
+++ b/test_project/test_project/management/commands/send_test_email.py
@@ -6,28 +6,28 @@ import magic
 
 
 class Command(BaseCommand):
-    help = 'Sends an email'
+    help = "Sends an email"
 
     def add_arguments(self, parser):
         #     parser.add_argument('to', nargs='+', type=str)
         #     parser.add_argument('cc', nargs='+', type=str)
         #     parser.add_argument('bcc', nargs='+', type=str)
         #     parser.add_argument('text-only', type=bool)
-        parser.add_argument('-a', '--attach-file', nargs='?', type=str, required=False)
+        parser.add_argument("-a", "--attach-file", nargs="?", type=str, required=False)
 
     def handle(self, *args, **options):
         m = mail.EmailMultiAlternatives(
-            'Subject here', 'The message in text/plain', 'test@example.com', ['to@example.com']
+            "Subject here", "The message in text/plain", "test@example.com", ["to@example.com"]
         )
         m.attach_alternative(
-            '<html><head>'
-            '<style>'
-            '@font-face {font-family: SourceCodePro; src: url(/static/fonts/SourceCodePro-Light.otf);}'
-            '</style>'
+            "<html><head>"
+            "<style>"
+            "@font-face {font-family: SourceCodePro; src: url(/static/fonts/SourceCodePro-Light.otf);}"
+            "</style>"
             '</head><body><p style="font-family: SourceCodePro; background-color: #AABBFF; color: white">The message as text/html</p></body></html>',
-            'text/html',
+            "text/html",
         )
-        attach_file = options.get('attach_file', '')
+        attach_file = options.get("attach_file", "")
         if attach_file:
             mime_type = magic.from_file(attach_file, mime=True)
             m.attach_file(attach_file, mime_type)

--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -9,10 +9,11 @@ https://docs.djangoproject.com/en/3.1/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.1/ref/settings/
 """
+
 import os
 
-DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
-EMAIL_BACKEND = 'django_mail_viewer.backends.database.EmailBackend'
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+EMAIL_BACKEND = "django_mail_viewer.backends.database.EmailBackend"
 # EMAIL_BACKEND = 'django_mail_viewer.backends.cache.EmailBackend'
 # CACHES = {
 #     'default': {
@@ -31,7 +32,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'kgt+q&n@9=r+^c!0u3n%6v9b$c#f+(=hxpvarg8+q4^3fdz*(^'
+SECRET_KEY = "kgt+q&n@9=r+^c!0u3n%6v9b$c#f+(=hxpvarg8+q4^3fdz*(^"
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -41,71 +42,84 @@ ALLOWED_HOSTS = []  # type: ignore
 # Application definition
 
 INSTALLED_APPS = [
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'django_mail_viewer',
-    'django_mail_viewer.backends.database.apps.DatabaseBackendConfig',
-    'test_project',
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "django_mail_viewer",
+    "django_mail_viewer.backends.database.apps.DatabaseBackendConfig",
+    "test_project",
 ]
 
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
-ROOT_URLCONF = 'test_project.urls'
+ROOT_URLCONF = "test_project.urls"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
             ],
         },
     },
 ]
 
-WSGI_APPLICATION = 'test_project.wsgi.application'
+WSGI_APPLICATION = "test_project.wsgi.application"
 
 
 # Database
 # https://docs.djangoproject.com/en/3.1/ref/settings/#databases
 
-DATABASES = {'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': BASE_DIR / 'db.sqlite3',}}
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
+    }
+}
 
 
 # Password validation
 # https://docs.djangoproject.com/en/3.1/ref/settings/#auth-password-validators
 
 AUTH_PASSWORD_VALIDATORS = [
-    {'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',},
-    {'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',},
-    {'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',},
-    {'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',},
+    {
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
+    },
 ]
 
 
 # Internationalization
 # https://docs.djangoproject.com/en/3.1/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = "UTC"
 
 USE_I18N = True
 
@@ -117,8 +131,6 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
 
-STATIC_URL = '/static/'
+STATIC_URL = "/static/"
 
-STATICFILES_DIRS = (
-    os.path.join(os.path.dirname(os.path.dirname(__file__)), 'static'),
-)
+STATICFILES_DIRS = (os.path.join(os.path.dirname(os.path.dirname(__file__)), "static"),)

--- a/test_project/test_project/urls.py
+++ b/test_project/test_project/urls.py
@@ -13,10 +13,11 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib import admin
 from django.urls import path, include
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
-    path('', include('django_mail_viewer.urls')),
+    path("admin/", admin.site.urls),
+    path("", include("django_mail_viewer.urls")),
 ]

--- a/test_project/test_project/wsgi.py
+++ b/test_project/test_project/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'test_project.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "test_project.settings")
 
 application = get_wsgi_application()

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,6 +1,7 @@
 """
 Test django_mail_viewer.backends
 """
+
 import json
 import shutil
 import threading
@@ -18,10 +19,10 @@ from typing import Any
 def send_plaintext_messages(count: int, connection: Any):
     for x in range(count):
         mail.EmailMultiAlternatives(
-            f'Email subject {x}',
-            f'Email text {x}',
-            'test@example.com',
-            ['to1@example.com', 'to2.example.com'],
+            f"Email subject {x}",
+            f"Email text {x}",
+            "test@example.com",
+            ["to1@example.com", "to2.example.com"],
             connection=connection,
         ).send()
 
@@ -31,7 +32,7 @@ class LocMemBackendTest(SimpleTestCase):
     Test django_mail_viewer.backends.locmem.EmailBackend
     """
 
-    connection_backend = 'django_mail_viewer.backends.locmem.EmailBackend'
+    connection_backend = "django_mail_viewer.backends.locmem.EmailBackend"
 
     def setUp(self):
         mail.outbox = []
@@ -42,7 +43,7 @@ class LocMemBackendTest(SimpleTestCase):
         """
 
         m = mail.EmailMultiAlternatives(
-            'Email 2 subject', 'Email 2 text', 'test@example.com', ['to1@example.com', 'to2.example.com']
+            "Email 2 subject", "Email 2 text", "test@example.com", ["to1@example.com", "to2.example.com"]
         )
         with mail.get_connection(self.connection_backend) as connection:
             self.assertEqual([], mail.outbox)
@@ -51,12 +52,12 @@ class LocMemBackendTest(SimpleTestCase):
 
     def test_get_message(self):
 
-        with mail.get_connection('django_mail_viewer.backends.locmem.EmailBackend') as connection:
+        with mail.get_connection("django_mail_viewer.backends.locmem.EmailBackend") as connection:
             send_plaintext_messages(2, connection)
             self.assertEqual(2, len(mail.outbox))
             for message in mail.outbox:
                 # check that we can use the message id to look up a specific message's data
-                self.assertEqual(message, connection.get_message(message.get('Message-ID')))
+                self.assertEqual(message, connection.get_message(message.get("Message-ID")))
 
     def test_get_outbox(self):
         with mail.get_connection(self.connection_backend) as connection:
@@ -70,15 +71,15 @@ class LocMemBackendTest(SimpleTestCase):
         """
         Test the delete() method of the backend deletes the message from the outbox
         """
-        with mail.get_connection('django_mail_viewer.backends.locmem.EmailBackend') as connection:
+        with mail.get_connection("django_mail_viewer.backends.locmem.EmailBackend") as connection:
             send_plaintext_messages(3, connection)
             target_message = connection.get_outbox()[1]
-            target_id = target_message.get('message-id')
+            target_id = target_message.get("message-id")
             connection.delete_message(target_id)
             self.assertEqual(2, len(connection.get_outbox()))
             for message in connection.get_outbox():
                 self.assertNotEqual(
-                    target_id, message.get('message-id'), f'Message with id {target_id} found in outbox after delete.'
+                    target_id, message.get("message-id"), f"Message with id {target_id} found in outbox after delete."
                 )
 
 
@@ -88,7 +89,7 @@ class CacheBackendTest(SimpleTestCase):
     """
 
     maxDiff = None
-    connection_backend = 'django_mail_viewer.backends.cache.EmailBackend'
+    connection_backend = "django_mail_viewer.backends.cache.EmailBackend"
 
     def setUp(self):
         # not sure this is the best way to do this, but it'll work for now
@@ -97,7 +98,7 @@ class CacheBackendTest(SimpleTestCase):
 
     def test_send_messages_adds_message_to_cache(self):
         m = mail.EmailMultiAlternatives(
-            'Email 2 subject', 'Email 2 text', 'test@example.com', ['to1@example.com', 'to2.example.com']
+            "Email 2 subject", "Email 2 text", "test@example.com", ["to1@example.com", "to2.example.com"]
         )
         with mail.get_connection(self.connection_backend) as connection:
             self.mail_cache.delete(connection.cache_keys_key)
@@ -116,7 +117,7 @@ class CacheBackendTest(SimpleTestCase):
                 # Not so obvious test here - we know our message ids from the cache, so we just check that looking up
                 # by the message id gets us an email message with the same Message-ID headers
                 # Could also iterate over connection.get_outbox()
-                self.assertEqual(message_id, connection.get_message(message_id).get('Message-ID'))
+                self.assertEqual(message_id, connection.get_message(message_id).get("Message-ID"))
 
     def test_get_outbox(self):
         with mail.get_connection(self.connection_backend) as connection:
@@ -128,10 +129,10 @@ class CacheBackendTest(SimpleTestCase):
             # TODO: A better comparison of the objects. This works for now, though
             message_cache_keys = cache.caches[settings.MAILVIEWER_CACHE].get(connection.cache_keys_key)
             expected = [
-                m.get('Message-ID')
+                m.get("Message-ID")
                 for m in cache.caches[settings.MAILVIEWER_CACHE].get_many(message_cache_keys).values()
             ]
-            actual = [m.get('Message-ID') for m in connection.get_outbox()]
+            actual = [m.get("Message-ID") for m in connection.get_outbox()]
             self.assertEqual(expected, actual)
 
     def test_delete_message(self):
@@ -141,12 +142,12 @@ class CacheBackendTest(SimpleTestCase):
         with mail.get_connection(self.connection_backend) as connection:
             send_plaintext_messages(3, connection)
             target_message = connection.get_outbox()[1]
-            target_id = target_message.get('message-id')
+            target_id = target_message.get("message-id")
             connection.delete_message(target_id)
             self.assertEqual(2, len(connection.get_outbox()))
             for message in connection.get_outbox():
                 self.assertNotEqual(
-                    target_id, message.get('message-id'), f'Message with id {target_id} found in outbox after delete.'
+                    target_id, message.get("message-id"), f"Message with id {target_id} found in outbox after delete."
                 )
 
     def test_cache_lock(self):
@@ -156,6 +157,7 @@ class CacheBackendTest(SimpleTestCase):
         results = []
         concurrency = 5
         with mail.get_connection(self.connection_backend) as connection:
+
             def concurrent(results):
                 try:
                     myid = "123-%s" % threading.current_thread().ident
@@ -167,6 +169,7 @@ class CacheBackendTest(SimpleTestCase):
                             results.append(False)
                 except Exception:
                     results.append(False)
+
             threads = []
             for i in range(concurrency):
                 threads.append(threading.Thread(target=concurrent, args=(results,)))
@@ -188,7 +191,7 @@ class CacheBackendTest(SimpleTestCase):
         messages = []
         for i in range(3, 8):
             m = mail.EmailMultiAlternatives(
-                f'Email {i} subject', f'Email {i} text', 'test_multi@example.com', [f'to{i}@example.com']
+                f"Email {i} subject", f"Email {i} text", "test_multi@example.com", [f"to{i}@example.com"]
             )
             messages.append(m)
         with mail.get_connection(self.connection_backend) as connection:
@@ -204,9 +207,9 @@ class CacheBackendTest(SimpleTestCase):
                 t.join()
             cache_keys = self.mail_cache.get(connection.cache_keys_key)
             self.assertEqual(5, len(cache_keys))
-            original_messages_before_message_id = [m.message().as_string().split('Message-ID:')[0] for m in messages]
+            original_messages_before_message_id = [m.message().as_string().split("Message-ID:")[0] for m in messages]
             for key in cache_keys:
-                sent_message_before_message_id = self.mail_cache.get(key).as_string().split('Message-ID:')[0]
+                sent_message_before_message_id = self.mail_cache.get(key).as_string().split("Message-ID:")[0]
                 self.assertIn(sent_message_before_message_id, original_messages_before_message_id)
 
 
@@ -215,7 +218,7 @@ class DatabaseBackendTest(TestCase):
     Test django_mail_viewer.backends.cache.EmailBackend
     """
 
-    connection_backend = 'django_mail_viewer.backends.database.backend.EmailBackend'
+    connection_backend = "django_mail_viewer.backends.database.backend.EmailBackend"
 
     @classmethod
     def tearDownClass(cls) -> None:
@@ -227,16 +230,16 @@ class DatabaseBackendTest(TestCase):
     def test_send_plaintext_email(self):
         original_email_count = EmailMessage.objects.count()
         m = mail.EmailMultiAlternatives(
-            'Email subject', 'Email text', 'test@example.com', ['to1@example.com', 'to2.example.com']
+            "Email subject", "Email text", "test@example.com", ["to1@example.com", "to2.example.com"]
         )
         with mail.get_connection(self.connection_backend) as connection:
             self.assertEqual(1, connection.send_messages([m]))
 
         self.assertEqual(original_email_count + 1, EmailMessage.objects.count())
-        email = EmailMessage.objects.latest('id')
+        email = EmailMessage.objects.latest("id")
 
         expected_headers = {
-            "Content-Type": "text/plain; charset=\"utf-8\"",
+            "Content-Type": 'text/plain; charset="utf-8"',
             "MIME-Version": "1.0",
             "Content-Transfer-Encoding": "7bit",
             "Subject": "Email subject",
@@ -247,36 +250,36 @@ class DatabaseBackendTest(TestCase):
         actual_headers = json.loads(email.message_headers)
         # Make sure there is a `Date` key in the headers and it has a value, but am not trying to match it up since
         # I have no good way of knowing what it should be.
-        self.assertTrue(actual_headers.get('Date'))
+        self.assertTrue(actual_headers.get("Date"))
         # Now remove the `Date` key so that the dicts can be compared.
-        del actual_headers['Date']
+        del actual_headers["Date"]
         self.assertEqual(expected_headers, actual_headers)
-        self.assertEqual('Email text', email.content)
+        self.assertEqual("Email text", email.content)
 
     def test_send_html_email_with_attachment(self):
         original_email_count = EmailMessage.objects.count()
         m = mail.EmailMultiAlternatives(
-            'Email subject', 'Email text', 'test@example.com', ['to1@example.com', 'to2.example.com']
+            "Email subject", "Email text", "test@example.com", ["to1@example.com", "to2.example.com"]
         )
 
         m.attach_alternative(
             '<html><body><p style="background-color: #AABBFF; color: white">Email html</p></body></html>',
-            'text/html',
+            "text/html",
         )
 
         current_dir = Path(__file__).resolve().parent
-        m.attach_file(current_dir / 'test_files' / 'icon.gif', 'image/gif')
+        m.attach_file(current_dir / "test_files" / "icon.gif", "image/gif")
 
         with mail.get_connection(self.connection_backend) as connection:
             self.assertEqual(1, connection.send_messages([m]))
 
         # The main message, the multipart/alternative, the text/plain, the text/html, and the attached img/gif
         self.assertEqual(original_email_count + 5, EmailMessage.objects.count())
-        email = EmailMessage.objects.filter(parent=None).exclude(message_id='').latest('id')
+        email = EmailMessage.objects.filter(parent=None).exclude(message_id="").latest("id")
 
         parts_test_matrix = {
-            'multipart/mixed': {
-                'headers': {
+            "multipart/mixed": {
+                "headers": {
                     "Content-Type": "multipart/mixed",
                     "MIME-Version": "1.0",
                     "Subject": "Email subject",
@@ -284,49 +287,49 @@ class DatabaseBackendTest(TestCase):
                     "To": "to1@example.com, to2.example.com",
                     "Message-ID": email.message_id,
                 },
-                'content': '',
-                'attachment': '',
-                'parent': None,
+                "content": "",
+                "attachment": "",
+                "parent": None,
             },
-            'multipart/alternative': {
-                'headers': {
-                    'Content-Type': 'multipart/alternative',
-                    'MIME-Version': '1.0',
+            "multipart/alternative": {
+                "headers": {
+                    "Content-Type": "multipart/alternative",
+                    "MIME-Version": "1.0",
                 },
-                'content': '',
-                'attachment': '',
-                'parent': email,
+                "content": "",
+                "attachment": "",
+                "parent": email,
             },
-            'text/plain': {
-                'headers': {
-                    'Content-Type': 'text/plain; charset=\"utf-8\"',
-                    'MIME-Version': '1.0',
-                    'Content-Transfer-Encoding': '7bit',
+            "text/plain": {
+                "headers": {
+                    "Content-Type": 'text/plain; charset="utf-8"',
+                    "MIME-Version": "1.0",
+                    "Content-Transfer-Encoding": "7bit",
                 },
-                'content': 'Email text',
-                'attachment': '',
-                'parent': email,
+                "content": "Email text",
+                "attachment": "",
+                "parent": email,
             },
-            'text/html': {
-                'headers': {
-                    'Content-Type': 'text/html; charset="utf-8"',
-                    'MIME-Version': '1.0',
-                    'Content-Transfer-Encoding': '7bit',
+            "text/html": {
+                "headers": {
+                    "Content-Type": 'text/html; charset="utf-8"',
+                    "MIME-Version": "1.0",
+                    "Content-Transfer-Encoding": "7bit",
                 },
-                'content': '<html><body><p style="background-color: #AABBFF; color: white">Email html</p></body></html>',
-                'attachment': '',
-                'parent': email,
+                "content": '<html><body><p style="background-color: #AABBFF; color: white">Email html</p></body></html>',
+                "attachment": "",
+                "parent": email,
             },
-            'image/gif': {
-                'headers': {
-                    'Content-Type': 'image/gif',
-                    'MIME-Version': '1.0',
-                    'Content-Transfer-Encoding': 'base64',
-                    'Content-Disposition': 'attachment; filename="icon.gif"',
+            "image/gif": {
+                "headers": {
+                    "Content-Type": "image/gif",
+                    "MIME-Version": "1.0",
+                    "Content-Transfer-Encoding": "base64",
+                    "Content-Disposition": 'attachment; filename="icon.gif"',
                 },
-                'content': '',
-                'attachment': 'mailviewer_attachments/icon.gif',
-                'parent': email,
+                "content": "",
+                "attachment": "mailviewer_attachments/icon.gif",
+                "parent": email,
             },
         }
 
@@ -340,13 +343,13 @@ class DatabaseBackendTest(TestCase):
                 current_test = parts_test_matrix[content_type]
                 tested_parts.append(content_type)
                 actual_headers = json.loads(part.message_headers)
-                if actual_headers.get('Date'):
+                if actual_headers.get("Date"):
                     # Now remove the `Date` key so that the dicts can be compared for the multipart/mixed
                     # would love to find a way to properly compare them
-                    del actual_headers['Date']
-                self.assertEqual(current_test['headers'], actual_headers)
-                self.assertEqual(current_test['content'], part.content)
-                self.assertEqual(current_test['attachment'], str(part.file_attachment))
+                    del actual_headers["Date"]
+                self.assertEqual(current_test["headers"], actual_headers)
+                self.assertEqual(current_test["content"], part.content)
+                self.assertEqual(current_test["attachment"], str(part.file_attachment))
 
         self.assertEqual(list(parts_test_matrix.keys()).sort(), tested_parts.sort())
 
@@ -376,10 +379,10 @@ class DatabaseBackendTest(TestCase):
         with mail.get_connection(self.connection_backend) as connection:
             send_plaintext_messages(3, connection)
             target_message = connection.get_outbox()[1]
-            target_id = target_message.get('message-id')
+            target_id = target_message.get("message-id")
             connection.delete_message(target_id)
             self.assertEqual(2, len(connection.get_outbox()))
             for message in connection.get_outbox():
                 self.assertNotEqual(
-                    target_id, message.get('message-id'), f'Message with id {target_id} found in outbox after delete.'
+                    target_id, message.get("message-id"), f"Message with id {target_id} found in outbox after delete."
                 )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,22 +9,22 @@ from django_mail_viewer.backends.database.models import EmailMessage
 
 
 class DatabaseBackendEmailMessageTest(TestCase):
-    connection_backend = 'django_mail_viewer.backends.database.backend.EmailBackend'
+    connection_backend = "django_mail_viewer.backends.database.backend.EmailBackend"
 
     @classmethod
     def setUpTestData(cls):
 
         m = mail.EmailMultiAlternatives(
-            'Email subject', 'Email text', 'test@example.com', ['to1@example.com', 'to2.example.com']
+            "Email subject", "Email text", "test@example.com", ["to1@example.com", "to2.example.com"]
         )
 
         m.attach_alternative(
             '<html><body><p style="background-color: #AABBFF; color: white">Email html</p></body></html>',
-            'text/html',
+            "text/html",
         )
 
         current_dir = Path(__file__).resolve().parent
-        m.attach_file(current_dir / 'test_files' / 'icon.gif', 'image/gif')
+        m.attach_file(current_dir / "test_files" / "icon.gif", "image/gif")
 
         with mail.get_connection(cls.connection_backend) as connection:
             connection.send_messages([m])
@@ -39,15 +39,15 @@ class DatabaseBackendEmailMessageTest(TestCase):
 
     def test_get(self):
         test_matrix = [
-            {'header_name': 'Content-Type', 'value': 'multipart/mixed'},
-            {'header_name': 'Subject', 'value': 'Email subject'},
+            {"header_name": "Content-Type", "value": "multipart/mixed"},
+            {"header_name": "Subject", "value": "Email subject"},
         ]
         for t in test_matrix:
-            with self.subTest(header=t['header_name']):
-                self.assertEqual(self.multipart_message.get(t['header_name']), t['value'])
+            with self.subTest(header=t["header_name"]):
+                self.assertEqual(self.multipart_message.get(t["header_name"]), t["value"])
                 # test that looking up by headeris not case sensitive
                 self.assertEqual(
-                    self.multipart_message.get(t['header_name']), self.multipart_message.get(t['header_name'].lower())
+                    self.multipart_message.get(t["header_name"]), self.multipart_message.get(t["header_name"].lower())
                 )
 
     def test_is_multipart(self):
@@ -55,35 +55,35 @@ class DatabaseBackendEmailMessageTest(TestCase):
 
         with mail.get_connection(self.connection_backend) as connection:
             mail.EmailMultiAlternatives(
-                'Not multipart',
-                'Not multipart',
-                'test@example.com',
-                ['to1@example.com', 'to2.example.com'],
+                "Not multipart",
+                "Not multipart",
+                "test@example.com",
+                ["to1@example.com", "to2.example.com"],
                 connection=connection,
             ).send()
 
-        m = EmailMessage.objects.filter(parent=None).latest('id')
+        m = EmailMessage.objects.filter(parent=None).latest("id")
         self.assertFalse(m.is_multipart())
 
     def test_walk(self):
         self.assertEqual(
-            list(EmailMessage.objects.filter(parent=self.multipart_message).order_by('-created_at', 'id')),
+            list(EmailMessage.objects.filter(parent=self.multipart_message).order_by("-created_at", "id")),
             list(self.multipart_message.walk()),
         )
 
     def test_get_content_type(self):
         # The main message followed by each of its parts
-        expected_content_types = ['multipart/mixed', 'multipart/alternative', 'text/plain', 'text/html', 'image/gif']
+        expected_content_types = ["multipart/mixed", "multipart/alternative", "text/plain", "text/html", "image/gif"]
         self.assertEqual(
             expected_content_types,
-            [m.get_content_type() for m in EmailMessage.objects.all().order_by('created_at', 'id')],
+            [m.get_content_type() for m in EmailMessage.objects.all().order_by("created_at", "id")],
         )
 
     def test_get_payload(self):
-        m = self.multipart_message.parts.exclude(file_attachment='').get()
+        m = self.multipart_message.parts.exclude(file_attachment="").get()
         # May need to seek back to 0 after this
         self.assertEqual(m.file_attachment.read(), m.get_payload())
 
     def test_get_filename(self):
-        m = self.multipart_message.parts.exclude(file_attachment='').get()
-        self.assertEqual('icon.gif', m.get_filename())
+        m = self.multipart_message.parts.exclude(file_attachment="").get()
+        self.assertEqual("icon.gif", m.get_filename())

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -6,9 +6,9 @@ from django.test.utils import override_settings
 from django.urls import reverse
 
 
-@override_settings(EMAIL_BACKEND='django_mail_viewer.backends.locmem.EmailBackend')
+@override_settings(EMAIL_BACKEND="django_mail_viewer.backends.locmem.EmailBackend")
 class EmailListViewTest(SimpleTestCase):
-    URL_NAME = 'mail_viewer_list'
+    URL_NAME = "mail_viewer_list"
 
     def test_get_returns_email_list(self):
         mail.outbox = []
@@ -17,29 +17,29 @@ class EmailListViewTest(SimpleTestCase):
             "Email 1 subject",
             "Email 1 text",
             "test@example.com",
-            ['to1@example.com', 'to2.example.com'],
-            html_message='<html><body>Email 1 HTML</body></html>',
+            ["to1@example.com", "to2.example.com"],
+            html_message="<html><body>Email 1 HTML</body></html>",
         )
 
         # email with attachment
         m = mail.EmailMultiAlternatives(
-            'Email 2 subject', 'Email 2 text', 'test@example.com', ['to1@example.com', 'to2.example.com']
+            "Email 2 subject", "Email 2 text", "test@example.com", ["to1@example.com", "to2.example.com"]
         )
         m.attach_alternative(
-            '<html><body><p style="background-color: #AABBFF; color: white">Email 2 HTML</p></body></html>', 'text/html'
+            '<html><body><p style="background-color: #AABBFF; color: white">Email 2 HTML</p></body></html>', "text/html"
         )
         current_dir = os.path.dirname(__file__)
-        files_dir = os.path.join(current_dir, 'test_files')
-        test_file_attachment = os.path.join(files_dir, 'icon.gif')
+        files_dir = os.path.join(current_dir, "test_files")
+        test_file_attachment = os.path.join(files_dir, "icon.gif")
         m.attach_file(test_file_attachment)
         m.send()
 
         response = self.client.get(reverse(self.URL_NAME))
         self.assertEqual(200, response.status_code)
-        self.assertEqual(mail.outbox, response.context['outbox'])
+        self.assertEqual(mail.outbox, response.context["outbox"])
         self.assertEqual(2, len(mail.outbox))
-        self.assertEqual(response.context['outbox'][0].get('subject'), 'Email 1 subject')
-        self.assertEqual(response.context['outbox'][1].get('subject'), 'Email 2 subject')
+        self.assertEqual(response.context["outbox"][0].get("subject"), "Email 1 subject")
+        self.assertEqual(response.context["outbox"][1].get("subject"), "Email 2 subject")
 
     def test_get_with_empty_list_has_200_response(self):
         mail.outbox = []
@@ -47,9 +47,9 @@ class EmailListViewTest(SimpleTestCase):
         self.assertEqual(200, response.status_code)
 
 
-@override_settings(EMAIL_BACKEND='django_mail_viewer.backends.locmem.EmailBackend')
+@override_settings(EMAIL_BACKEND="django_mail_viewer.backends.locmem.EmailBackend")
 class EmailDetailViewTest(SimpleTestCase):
-    URL_NAME = 'mail_viewer_detail'
+    URL_NAME = "mail_viewer_detail"
 
     def setUp(self, *args, **kwargs):
         super().setUp(*args, **kwargs)
@@ -57,8 +57,8 @@ class EmailDetailViewTest(SimpleTestCase):
 
     def _get_detail_url(self, message_id=None):
         if not message_id:
-            message_id = mail.outbox[0].get('message-id')
-            message_id = message_id.strip('<>')
+            message_id = mail.outbox[0].get("message-id")
+            message_id = message_id.strip("<>")
         return reverse(self.URL_NAME, args=[message_id])
 
     def test_templates_used(self):
@@ -69,111 +69,111 @@ class EmailDetailViewTest(SimpleTestCase):
             "Email 1 subject",
             "Email 1 text",
             "test@example.com",
-            ['to1@example.com', 'to2.example.com'],
-            html_message='<html><body>Email 1 HTML</body></html>',
+            ["to1@example.com", "to2.example.com"],
+            html_message="<html><body>Email 1 HTML</body></html>",
         )
 
         test_matrix = [
             # This order is interesting...
-            {'headers': {'HTTP_HX_REQUEST': True}, 'template': ['mail_viewer/email_detail_content_fragment.html']},
+            {"headers": {"HTTP_HX_REQUEST": True}, "template": ["mail_viewer/email_detail_content_fragment.html"]},
             {
-                'headers': {},
-                'template': [
-                    'mail_viewer/email_detail.html',
-                    'mail_viewer/base.html',
-                    'mail_viewer/email_detail_content_fragment.html',
+                "headers": {},
+                "template": [
+                    "mail_viewer/email_detail.html",
+                    "mail_viewer/base.html",
+                    "mail_viewer/email_detail_content_fragment.html",
                 ],
             },
         ]
         for t in test_matrix:
-            with self.subTest(**t['headers']):
-                response = self.client.get(self._get_detail_url(), **t['headers'])
+            with self.subTest(**t["headers"]):
+                response = self.client.get(self._get_detail_url(), **t["headers"])
                 self.assertEqual(200, response.status_code)
-                self.assertEqual(t['template'], [template.name for template in response.templates])
+                self.assertEqual(t["template"], [template.name for template in response.templates])
 
     def test_view_context(self):
         mail.send_mail(
             "Email 1 subject",
             "Email 1 text",
             "test@example.com",
-            ['to1@example.com', 'to2.example.com'],
-            html_message='<html><body>Email 1 HTML</body></html>',
+            ["to1@example.com", "to2.example.com"],
+            html_message="<html><body>Email 1 HTML</body></html>",
         )
 
         response = self.client.get(self._get_detail_url())
         self.assertEqual(200, response.status_code)
-        expected_context = ['message', 'text_body', 'html_body', 'attachments', 'lookup_id', 'outbox']
+        expected_context = ["message", "text_body", "html_body", "attachments", "lookup_id", "outbox"]
         for x in expected_context:
             self.assertTrue(x in response.context)
 
     def test_get_returns_email_details(self):
         m = mail.EmailMultiAlternatives(
-            'Email 2 Subject', 'Email 2 text', 'test@example.com', ['to1@example.com', 'to2.example.com']
+            "Email 2 Subject", "Email 2 text", "test@example.com", ["to1@example.com", "to2.example.com"]
         )
         m.attach_alternative(
-            '<html><body><p style="background-color: #AABBFF; color: white">Email 2 HTML</p></body></html>', 'text/html'
+            '<html><body><p style="background-color: #AABBFF; color: white">Email 2 HTML</p></body></html>', "text/html"
         )
         current_dir = os.path.dirname(__file__)
-        files_dir = os.path.join(current_dir, 'test_files')
-        test_file_attachment = os.path.join(files_dir, 'icon.gif')
+        files_dir = os.path.join(current_dir, "test_files")
+        test_file_attachment = os.path.join(files_dir, "icon.gif")
         m.attach_file(test_file_attachment)
         m.send()
 
-        message_id = mail.outbox[0].get('message-id')
-        response = self.client.get(self._get_detail_url(message_id.strip('<>')))
+        message_id = mail.outbox[0].get("message-id")
+        response = self.client.get(self._get_detail_url(message_id.strip("<>")))
         self.assertEqual(200, response.status_code)
 
-        self.assertEqual('Email 2 text', response.context['text_body'])
+        self.assertEqual("Email 2 text", response.context["text_body"])
         self.assertEqual(
             '<html><body><p style="background-color: #AABBFF; color: white">Email 2 HTML</p></body></html>',
-            response.context['html_body'],
+            response.context["html_body"],
         )
         self.assertEqual(
-            [{'filename': 'icon.gif', 'content_type': 'image/gif', 'file': None}], response.context['attachments']
+            [{"filename": "icon.gif", "content_type": "image/gif", "file": None}], response.context["attachments"]
         )
-        self.assertEqual(mail.outbox[0], response.context['message'])
-        self.assertEqual(mail.outbox, response.context['outbox'])
-        self.assertEqual(response.context['lookup_id'], message_id.strip('<>'))
+        self.assertEqual(mail.outbox[0], response.context["message"])
+        self.assertEqual(mail.outbox, response.context["outbox"])
+        self.assertEqual(response.context["lookup_id"], message_id.strip("<>"))
 
     def test_missing_email_redirect_to_list(self):
         """
         If a missing email id is given, rather than 404, this should just redirect back to the list view
         for ease of use.
         """
-        response = self.client.get(self._get_detail_url('fake-message-id'))
-        self.assertRedirects(response, reverse('mail_viewer_list'))
+        response = self.client.get(self._get_detail_url("fake-message-id"))
+        self.assertRedirects(response, reverse("mail_viewer_list"))
 
 
-@override_settings(EMAIL_BACKEND='django_mail_viewer.backends.locmem.EmailBackend')
+@override_settings(EMAIL_BACKEND="django_mail_viewer.backends.locmem.EmailBackend")
 class EmailAttachmentDownloadViewTest(SimpleTestCase):
-    URL_NAME = 'mail_viewer_attachment'
+    URL_NAME = "mail_viewer_attachment"
 
     def setUp(self):
         mail.outbox = []
 
     def test_get_sends_file_as_attachment(self):
         m = mail.EmailMultiAlternatives(
-            'Email 2 Subject', 'Email 2 text', 'test@example.com', ['to1@example.com', 'to2.example.com']
+            "Email 2 Subject", "Email 2 text", "test@example.com", ["to1@example.com", "to2.example.com"]
         )
         m.attach_alternative(
-            '<html><body><p style="background-color: #AABBFF; color: white">Email 2 HTML</p></body></html>', 'text/html'
+            '<html><body><p style="background-color: #AABBFF; color: white">Email 2 HTML</p></body></html>', "text/html"
         )
         current_dir = os.path.dirname(__file__)
-        files_dir = os.path.join(current_dir, 'test_files')
-        test_file_attachment = os.path.join(files_dir, 'icon.gif')
-        m.attach_file(test_file_attachment, 'image/gif')
+        files_dir = os.path.join(current_dir, "test_files")
+        test_file_attachment = os.path.join(files_dir, "icon.gif")
+        m.attach_file(test_file_attachment, "image/gif")
         m.send()
 
-        message_id = mail.outbox[0].get('message-id').strip('<>')
+        message_id = mail.outbox[0].get("message-id").strip("<>")
         response = self.client.get(reverse(self.URL_NAME, args=[message_id, 0]))
         self.assertEqual(200, response.status_code)
-        self.assertEqual('image/gif', response['Content-Type'])
-        self.assertEqual('attachment; filename=icon.gif', response['Content-Disposition'])
+        self.assertEqual("image/gif", response["Content-Type"])
+        self.assertEqual("attachment; filename=icon.gif", response["Content-Disposition"])
 
 
-@override_settings(EMAIL_BACKEND='django_mail_viewer.backends.locmem.EmailBackend')
+@override_settings(EMAIL_BACKEND="django_mail_viewer.backends.locmem.EmailBackend")
 class EmailDeleteViewTest(SimpleTestCase):
-    URL_NAME = 'mail_viewer_delete'
+    URL_NAME = "mail_viewer_delete"
 
     def setUp(self, *args, **kwargs):
         super().setUp(*args, **kwargs)
@@ -181,8 +181,8 @@ class EmailDeleteViewTest(SimpleTestCase):
 
     def _get_detail_url(self, message_id=None):
         if not message_id:
-            message_id = mail.outbox[0].get('message-id')
-            message_id = message_id.strip('<>')
+            message_id = mail.outbox[0].get("message-id")
+            message_id = message_id.strip("<>")
         return reverse(self.URL_NAME, args=[message_id])
 
     def test_get(self):
@@ -193,15 +193,15 @@ class EmailDeleteViewTest(SimpleTestCase):
             "Email 1 subject",
             "Email 1 text",
             "test@example.com",
-            ['to1@example.com', 'to2.example.com'],
-            html_message='<html><body>Email 1 HTML</body></html>',
+            ["to1@example.com", "to2.example.com"],
+            html_message="<html><body>Email 1 HTML</body></html>",
         )
 
         with mail.get_connection() as connection:
             self.assertEqual(1, len(list(connection.get_outbox())))
 
         response = self.client.get(self._get_detail_url())
-        self.assertEqual(mail.outbox[0], response.context['message'])
+        self.assertEqual(mail.outbox[0], response.context["message"])
 
     def test_post(self):
         """
@@ -211,8 +211,8 @@ class EmailDeleteViewTest(SimpleTestCase):
             "Email 1 subject",
             "Email 1 text",
             "test@example.com",
-            ['to1@example.com', 'to2.example.com'],
-            html_message='<html><body>Email 1 HTML</body></html>',
+            ["to1@example.com", "to2.example.com"],
+            html_message="<html><body>Email 1 HTML</body></html>",
         )
 
         with mail.get_connection() as connection:
@@ -230,8 +230,8 @@ class EmailDeleteViewTest(SimpleTestCase):
             "Email 1 subject",
             "Email 1 text",
             "test@example.com",
-            ['to1@example.com', 'to2.example.com'],
-            html_message='<html><body>Email 1 HTML</body></html>',
+            ["to1@example.com", "to2.example.com"],
+            html_message="<html><body>Email 1 HTML</body></html>",
         )
 
         with mail.get_connection() as connection:

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,18 @@
 [tox]
 envlist =
-    {py37,py38,py39,py310}-django-32
-    {py38,py39,py310,311}-django-40
-    {py38,py39,py310,311}-django-41
+    {py38,py39,py310,311,312}-django-42
+    {py310,311,312}-django-50
+    {py310,311,312}-django-51
+    {py310,311,312}-django-52
     stats
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
+    3.11: py312
 
 [testenv]
 setenv =
@@ -27,11 +28,11 @@ deps =
     -r{toxinidir}/requirements_test.txt
 
 basepython =
-    py37: python3.7
     py38: python3.8
     py39: python3.9
     py310: python3.10
     py311: python3.11
+    py312: python3.12
     stats: python3.9
 
 [testenv:stats]


### PR DESCRIPTION
Updating tons of small stuff... linter and formatter choices and configs, dropping no longer supported versions of python and django based on official support levels, adding python 3.12 and django 5.0 through 5.2.